### PR TITLE
fixed minio url and added debug logging

### DIFF
--- a/app/utils/minio.py
+++ b/app/utils/minio.py
@@ -1,4 +1,5 @@
 from minio import Minio
+from minio.error import S3Error
 import os
 import logging
 
@@ -22,13 +23,11 @@ def createBucket (client):
 def uploadImage (client, image_path, image_name):
     try:
         createBucket(client)
-
-        with open(image_path, 'rb') as image_file:
-            client.fput_object(
-                "profiles",
-                image_name,
-                image_file,
-            )
+        client.fput_object(
+            "profiles",
+            image_name,
+            image_path,
+        )
         logging.info(f"Image '{image_name}' uploaded successfully to bucket 'profiles'.")
     except S3Error as e:
         logging.error(f"Error uploading image '{image_name}': {e}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,9 @@ services:
     networks:
       - app-network
     environment:
-      MINIO_URL: http://minio:9000
-      MINIO_ACCESS_KEY: u5ODd68aboNGfqh9U3jx
-      MINIO_SECRET_KEY: UC5ACGQQlf5kDuTCvu0loZnMZEeRmyQIMnVeDYfH
+      MINIO_URL: minio:9000
+      MINIO_ACCESS_KEY: SEYNQEv1ImC8xg01Dxt4
+      MINIO_SECRET_KEY: Zszwj2uSLGFksgJxRsO36faVsniUfxSwykS9InIc
 
   nginx:
     image: nginx:latest


### PR DESCRIPTION
No registered access keys found in MinIO Console and environment variable for ```MINIO_URL``` included ```http://``` causing the 500 error for Issue #1. 

These changes provide updated access/secret keys, add debugging log statements to upload profile picture endpoint, and remove the http prefix from ```MINIO_URL```.

Now, items are successfully being stored in the MinIO profile bucket. These changes close #1.