### PR TITLE
updated production.yml 

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -37,7 +37,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        command: server /data --console-address ":9001"
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
Included minio in production workflow, initially missing causing tests to fail in production workflow. 
Removed command value causing error.

Fixes #3 